### PR TITLE
modify:強化NLP辨識能力 #63

### DIFF
--- a/apps/nlp_validation/processors.py
+++ b/apps/nlp_validation/processors.py
@@ -83,15 +83,34 @@ class EntityExtractor:
             "mobile_payment": ["行動支付", "手機支付", "數位支付", "電子支付"],
             "department_store": ["百貨", "百貨公司", "購物中心", "商場"],
             "convenience_store": ["便利商店", "7-11", "全家", "萊爾富", "OK"],
-            "momo": ["momo", "富邦momo", "momo購物", "momo網"],
-            "pchome": ["pchome", "pc home", "露天", "pc商店街", "pchome24h"],
-            "shopee": ["蝦皮", "shopee", "蝦皮購物"],
-            "yahoo": ["yahoo", "奇摩", "yahoo購物"],
-            "uber": ["uber", "uber eats", "ubereats"],
-            "foodpanda": ["foodpanda", "熊貓", "panda"],
-            "netflix": ["netflix", "網飛"],
-            "spotify": ["spotify"],
-            "coupang": ["coupang", "酷彭"],
+            "e_commerce": [
+                "momo",
+                "富邦momo",
+                "momo購物",
+                "momo網",
+                "pchome",
+                "pc home",
+                "露天",
+                "pc商店街",
+                "pchome24h",
+                "蝦皮",
+                "shopee",
+                "蝦皮購物",
+                "yahoo",
+                "奇摩",
+                "yahoo購物",
+                "uber",
+                "uber eats",
+                "ubereats",
+                "foodpanda",
+                "熊貓",
+                "panda",
+                "netflix",
+                "網飛",
+                "spotify",
+                "coupang",
+                "酷彭",
+            ],
         }
 
         # 電商
@@ -109,9 +128,10 @@ class EntityExtractor:
 
     def identify_category_from_context(self, context):
         # 用前後文分類類別
+        context_lower = context.lower()
         for category, keywords in self.category_mapping.items():
             for keyword in keywords:
-                if keyword in context:
+                if keyword.lower() in context_lower:
                     return category
 
         return None
@@ -137,8 +157,6 @@ class EntityExtractor:
             r"(\d+\.?\d*)%.*?回饋",
             r"回饋.*?(\d+\.?\d*)%",
             r"享.*?(\d+\.?\d*)%",
-            r"(\d+\.?\d*)趴",
-            r"百分之(\d+\.?\d*)",
             r"消費.*?(\d+\.?\d*)%",
             r"為(\d+\.?\d*)%.*?回饋",
             r"(\d+\.?\d*)%現金",
@@ -152,7 +170,7 @@ class EntityExtractor:
                 if not (0 < rate <= 20):
                     continue
 
-                context = text[max(0, match.start() - 0) : match.end()].strip()
+                context = text[max(0, match.start() - 10) : match.end()].strip()
 
                 category = self.identify_category_from_context(context)
                 merchant = self.identify_merchant_from_context(context)
@@ -185,9 +203,10 @@ class EntityExtractor:
     def extract_categories(self, text):
         # 消費分類
         found_categories = []
+        text_lower = text.lower()
 
         for category_key, keywords in self.category_mapping.items():
-            if any(keyword in text for keyword in keywords):
+            if any(keyword.lower() in text_lower for keyword in keywords):
                 found_categories.append(category_key)
 
         return found_categories

--- a/apps/nlp_validation/processors.py
+++ b/apps/nlp_validation/processors.py
@@ -75,7 +75,7 @@ class EntityExtractor:
     def __init__(self):
         self.processor = TextProcessor()
 
-        # 同義詞
+        # 同義詞/回饋類別
         self.category_mapping = {
             "foreign_transaction": ["國外", "海外", "境外", "國際", "外幣", "外國"],
             "domestic_transaction": ["國內", "本土", "台灣", "境內", "台灣境內"],
@@ -83,9 +83,18 @@ class EntityExtractor:
             "mobile_payment": ["行動支付", "手機支付", "數位支付", "電子支付"],
             "department_store": ["百貨", "百貨公司", "購物中心", "商場"],
             "convenience_store": ["便利商店", "7-11", "全家", "萊爾富", "OK"],
+            "momo": ["momo", "富邦momo", "momo購物", "momo網"],
+            "pchome": ["pchome", "pc home", "露天", "pc商店街", "pchome24h"],
+            "shopee": ["蝦皮", "shopee", "蝦皮購物"],
+            "yahoo": ["yahoo", "奇摩", "yahoo購物"],
+            "uber": ["uber", "uber eats", "ubereats"],
+            "foodpanda": ["foodpanda", "熊貓", "panda"],
+            "netflix": ["netflix", "網飛"],
+            "spotify": ["spotify"],
+            "coupang": ["coupang", "酷彭"],
         }
 
-        # 商家
+        # 電商
         self.merchant_patterns = {
             "momo": ["momo", "富邦momo", "momo購物", "momo網"],
             "pchome": ["pchome", "pc home", "露天", "pc商店街", "pchome24h"],
@@ -98,10 +107,31 @@ class EntityExtractor:
             "coupang": ["coupang", "酷彭"],
         }
 
+    def identify_category_from_context(self, context):
+        # 用前後文分類類別
+        for category, keywords in self.category_mapping.items():
+            for keyword in keywords:
+                if keyword in context:
+                    return category
+
+        return None
+
+    def identify_merchant_from_context(self, context):
+        # 用前後文分類電商
+        context_lower = context.lower()
+        for merchant, patterns in self.merchant_patterns.items():
+            for pattern in patterns:
+                if pattern.lower() in context_lower:
+                    return merchant
+        return None
+
     def extract_reward_rates(self, text):
+        # 資訊處裡
+        text = re.sub(r"(\d+\.?\d*)\s*\n\s*%", r"\1%", text)
+        text = re.sub(r"(\d+\.?\d*)\s{2,}%", r"\1%", text)
         # 回饋資訊
         results = []
-        seen_rates = set()
+        seen_combinations = set()
         # 回饋率
         patterns = [
             r"(\d+\.?\d*)%.*?回饋",
@@ -119,13 +149,24 @@ class EntityExtractor:
             matches = re.finditer(pattern, text)
             for match in matches:
                 rate = float(match.group(1))
-                if rate not in seen_rates:
-                    seen_rates.add(rate)
-                    context = text[max(0, match.start() - 50) : match.end() + 50]
+                if not (0 < rate <= 20):
+                    continue
+
+                context = text[max(0, match.start() - 0) : match.end()].strip()
+
+                category = self.identify_category_from_context(context)
+                merchant = self.identify_merchant_from_context(context)
+
+                combination_key = (rate, category, merchant)
+                if combination_key not in seen_combinations:
+                    seen_combinations.add(combination_key)
+
                     results.append(
                         {
                             "rate": rate,
-                            "context": context.strip(),
+                            "context": context,
+                            "category": category,
+                            "merchant": merchant,
                         }
                     )
 
@@ -141,7 +182,7 @@ class EntityExtractor:
 
         return found_merchants
 
-    def extract_categories(self, text: str) -> list[str]:
+    def extract_categories(self, text):
         # 消費分類
         found_categories = []
 


### PR DESCRIPTION
## 強化項目
- [x] 增加回饋項目類別
- [x] 增加回饋項目限制
- [x] 調整關鍵字辨別邏輯
- [x] 增加前後文關聯辨別
- [x] 增加回饋類別與回饋率的對應關係
### 但是輸出還是會被誤判多種相同回饋
結果：[test_01.json](https://github.com/user-attachments/files/22008691/test_01.json)

close #63 