### PR TITLE
feat: 註冊會員流程與驗證建立 (不包含第三方google) #65

### DIFF
--- a/Rewardia/settings.py
+++ b/Rewardia/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 from pathlib import Path
 from dotenv import load_dotenv
+from django.contrib.messages import constants as messages
 
 load_dotenv()
 
@@ -154,7 +155,6 @@ INTERNAL_IPS = [
 ]
 
 # 自訂 alert 類別(目前用於register.html)
-from django.contrib.messages import constants as messages
 MESSAGE_TAGS = {
     messages.SUCCESS: 'alert-success',
     messages.ERROR: 'alert-error',

--- a/Rewardia/settings.py
+++ b/Rewardia/settings.py
@@ -152,3 +152,10 @@ INTERNAL_IPS = [
     "127.0.0.1",
     "localhost",
 ]
+
+# 自訂 alert 類別(目前用於register.html)
+from django.contrib.messages import constants as messages
+MESSAGE_TAGS = {
+    messages.SUCCESS: 'alert-success',
+    messages.ERROR: 'alert-error',
+}

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -1,0 +1,131 @@
+from django import forms
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+import re
+
+
+class UserRegistrationForm(forms.Form):
+    """使用者註冊表單"""
+    
+    username = forms.CharField(
+        max_length=150,
+        required=True,
+        widget=forms.TextInput(attrs={
+            'class': 'input input-bordered w-full',
+            'placeholder': '請輸入帳號',
+            'id': 'username'
+        }),
+        label='帳號'
+    )
+    
+    email = forms.EmailField(
+        required=True,
+        widget=forms.EmailInput(attrs={
+            'class': 'input input-bordered w-full',
+            'placeholder': '請輸入電子信箱',
+            'id': 'email'
+        }),
+        label='電子信箱'
+    )
+    
+    password = forms.CharField(
+        min_length=8,
+        max_length=20,
+        required=True,
+        widget=forms.PasswordInput(attrs={
+            'class': 'input input-bordered w-full',
+            'placeholder': '請輸入密碼',
+            'id': 'password'
+        }),
+        label='密碼'
+    )
+    
+    confirm_password = forms.CharField(
+        min_length=8,
+        max_length=20,
+        required=True,
+        widget=forms.PasswordInput(attrs={
+            'class': 'input input-bordered w-full',
+            'placeholder': '請再次輸入密碼',
+            'id': 'confirm_password'
+        }),
+        label='確認密碼'
+    )
+    
+    agree_terms = forms.BooleanField(
+        required=True,
+        widget=forms.CheckboxInput(attrs={
+            'class': 'checkbox checkbox-primary',
+            'id': 'agree_terms'
+        }),
+        label='我同意網站服務條款'
+    )
+    
+    def clean_username(self):
+        """驗證帳號格式"""
+        username = self.cleaned_data.get('username')
+        
+        if not username:
+            raise ValidationError('帳號為必填項目')
+        
+        # 檢查是否只包含數字和英文大小寫，不能有空格
+        if not re.match(r'^[a-zA-Z0-9]+$', username):
+            raise ValidationError('帳號只能包含英文字母和數字，不能有空格或特殊字元')
+        
+        # 檢查帳號是否已存在
+        if User.objects.filter(username=username).exists():
+            raise ValidationError('此帳號已被使用，請選擇其他帳號')
+        
+        return username
+    
+    def clean_email(self):
+        """驗證電子信箱格式和唯一性"""
+        email = self.cleaned_data.get('email')
+        
+        if not email:
+            raise ValidationError('電子信箱為必填項目')
+        
+        # Django EmailField 已經處理基本格式驗證
+        # 檢查信箱是否已存在
+        if User.objects.filter(email=email).exists():
+            raise ValidationError('此電子信箱已被使用，請使用其他信箱')
+        
+        return email
+    
+    def clean_password(self):
+        """驗證密碼格式"""
+        password = self.cleaned_data.get('password')
+        
+        if not password:
+            raise ValidationError('密碼為必填項目')
+        
+        # 檢查密碼長度
+        if len(password) < 8 or len(password) > 20:
+            raise ValidationError('密碼長度必須在 8-20 個字元之間')
+        
+        # 檢查是否只包含數字和英文大小寫，不能有空格
+        if not re.match(r'^[a-zA-Z0-9]+$', password):
+            raise ValidationError('密碼只能包含英文字母和數字，不能有空格或特殊字元')
+        
+        # 檢查是否包含至少一個大寫字母
+        if not re.search(r'[A-Z]', password):
+            raise ValidationError('密碼必須包含至少一個英文大寫字母')
+        
+        # 檢查是否包含至少一個小寫字母
+        if not re.search(r'[a-z]', password):
+            raise ValidationError('密碼必須包含至少一個英文小寫字母')
+        
+        return password
+    
+    def clean(self):
+        """驗證整個表單，特別是密碼確認"""
+        cleaned_data = super().clean()
+        password = cleaned_data.get('password')
+        confirm_password = cleaned_data.get('confirm_password')
+        
+        # 檢查密碼確認是否一致
+        if password and confirm_password:
+            if password != confirm_password:
+                raise ValidationError('兩次輸入的密碼不一致，請重新確認')
+        
+        return cleaned_data

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -70,7 +70,7 @@ class UserRegistrationForm(forms.Form):
             raise ValidationError('帳號只能包含英文字母和數字，不能有空格或特殊字元')
         
         if not UserRegistrationService.check_username_availability(username):
-            raise ValidationError('此帳號已被使用，請選擇其他帳號')
+            raise ValidationError('此帳號已被使用，請選擇其他帳號', code='username_in_use')
         
         return username
     
@@ -79,7 +79,7 @@ class UserRegistrationForm(forms.Form):
         email = self.cleaned_data.get('email')
         
         if not UserRegistrationService.check_email_availability(email):
-            raise ValidationError('此電子信箱已被使用，請使用其他信箱')
+            raise ValidationError('此電子信箱已被使用，請使用其他信箱', code='email_in_use')
         
         return email
     
@@ -104,9 +104,8 @@ class UserRegistrationForm(forms.Form):
         password = cleaned_data.get('password')
         confirm_password = cleaned_data.get('confirm_password')
         
-        if password and confirm_password:
-            if password != confirm_password:
-                raise ValidationError('兩次輸入的密碼不一致，請重新確認')
+        if password and confirm_password and password != confirm_password:
+            self.add_error('confirm_password', '兩次輸入的密碼不一致，請重新確認')
         
         return cleaned_data
 

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 import re
+from .services import UserRegistrationService
 
 
 class UserRegistrationForm(forms.Form):
@@ -62,56 +63,36 @@ class UserRegistrationForm(forms.Form):
     )
     
     def clean_username(self):
-        """驗證帳號格式"""
+        """驗證帳號格式和唯一性"""
         username = self.cleaned_data.get('username')
         
-        if not username:
-            raise ValidationError('帳號為必填項目')
-        
-        # 檢查是否只包含數字和英文大小寫，不能有空格
         if not re.match(r'^[a-zA-Z0-9]+$', username):
             raise ValidationError('帳號只能包含英文字母和數字，不能有空格或特殊字元')
         
-        # 檢查帳號是否已存在
-        if User.objects.filter(username=username).exists():
+        if not UserRegistrationService.check_username_availability(username):
             raise ValidationError('此帳號已被使用，請選擇其他帳號')
         
         return username
     
     def clean_email(self):
-        """驗證電子信箱格式和唯一性"""
+        """驗證電子信箱唯一性"""
         email = self.cleaned_data.get('email')
         
-        if not email:
-            raise ValidationError('電子信箱為必填項目')
-        
-        # Django EmailField 已經處理基本格式驗證
-        # 檢查信箱是否已存在
-        if User.objects.filter(email=email).exists():
+        if not UserRegistrationService.check_email_availability(email):
             raise ValidationError('此電子信箱已被使用，請使用其他信箱')
         
         return email
     
     def clean_password(self):
-        """驗證密碼格式"""
+        """驗證密碼格式和強度"""
         password = self.cleaned_data.get('password')
         
-        if not password:
-            raise ValidationError('密碼為必填項目')
-        
-        # 檢查密碼長度
-        if len(password) < 8 or len(password) > 20:
-            raise ValidationError('密碼長度必須在 8-20 個字元之間')
-        
-        # 檢查是否只包含數字和英文大小寫，不能有空格
         if not re.match(r'^[a-zA-Z0-9]+$', password):
             raise ValidationError('密碼只能包含英文字母和數字，不能有空格或特殊字元')
         
-        # 檢查是否包含至少一個大寫字母
         if not re.search(r'[A-Z]', password):
             raise ValidationError('密碼必須包含至少一個英文大寫字母')
         
-        # 檢查是否包含至少一個小寫字母
         if not re.search(r'[a-z]', password):
             raise ValidationError('密碼必須包含至少一個英文小寫字母')
         
@@ -123,9 +104,20 @@ class UserRegistrationForm(forms.Form):
         password = cleaned_data.get('password')
         confirm_password = cleaned_data.get('confirm_password')
         
-        # 檢查密碼確認是否一致
         if password and confirm_password:
             if password != confirm_password:
                 raise ValidationError('兩次輸入的密碼不一致，請重新確認')
         
         return cleaned_data
+
+    def save(self):
+        """創建新用戶並返回用戶對象"""
+        if not self.is_valid():
+            raise ValueError("表單驗證失敗，無法保存用戶")
+        
+        user = User.objects.create_user(
+            username=self.cleaned_data['username'],
+            email=self.cleaned_data['email'],
+            password=self.cleaned_data['password']
+        )
+        return user

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -1,0 +1,60 @@
+from django.contrib import messages
+from django.contrib.auth.models import User
+
+
+class UserRegistrationService:
+    """用戶註冊服務類"""
+    
+    @staticmethod
+    def register_user(form):
+        """
+        註冊新用戶
+        會return (success: bool, user: User|None, error_type: str|None)
+        """
+        if not form.is_valid():
+            return False, None, 'validation_error'
+        
+        try:
+            user = form.save()
+            return True, user, None
+        except Exception as e:
+            return False, None, 'database_error'
+    
+    @staticmethod
+    def handle_registration_success(request, user):
+        """處理註冊成功"""
+        messages.success(request, f'歡迎 {user.username}！註冊成功，請登入您的帳號。')
+        
+
+    
+    @staticmethod
+    def handle_registration_failure(request, error_type, form=None):
+        """處理註冊失敗"""
+        if error_type == 'validation_error':
+            UserRegistrationService._handle_validation_errors(request, form)
+        elif error_type == 'database_error':
+            messages.error(request, '註冊過程發生系統錯誤，請稍後再試。')
+        else:
+            messages.error(request, '註冊失敗，請檢查您的輸入並重試。')
+    
+    @staticmethod
+    def _handle_validation_errors(request, form):
+        """處理表單驗證錯誤"""
+        for field, errors in form.errors.items():
+            for error in errors:
+                if '帳號已被使用' in str(error):
+                    messages.error(request, f'此帳號已被註冊，請選擇其他帳號或嘗試登入。')
+                elif '電子信箱已被使用' in str(error):
+                    messages.error(request, f'此電子信箱已被註冊，請使用其他信箱或嘗試登入。')
+                else:
+                    messages.error(request, error)
+    
+    @staticmethod
+    def check_username_availability(username):
+        """檢查帳號是否可用"""
+        return not User.objects.filter(username=username).exists()
+    
+    @staticmethod
+    def check_email_availability(email):
+        """檢查 email 是否可用"""
+        return not User.objects.filter(email=email).exists()

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -1,5 +1,9 @@
 from django.contrib import messages
 from django.contrib.auth.models import User
+from django.db import IntegrityError
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class UserRegistrationService:
@@ -17,7 +21,8 @@ class UserRegistrationService:
         try:
             user = form.save()
             return True, user, None
-        except Exception as e:
+        except IntegrityError as e:
+            logger.error(f"Database integrity error during user registration: {e}")
             return False, None, 'database_error'
     
     @staticmethod
@@ -42,19 +47,20 @@ class UserRegistrationService:
         """處理表單驗證錯誤"""
         for field, errors in form.errors.items():
             for error in errors:
-                if '帳號已被使用' in str(error):
-                    messages.error(request, f'此帳號已被註冊，請選擇其他帳號或嘗試登入。')
-                elif '電子信箱已被使用' in str(error):
-                    messages.error(request, f'此電子信箱已被註冊，請使用其他信箱或嘗試登入。')
+                error_code = getattr(error, 'code', None)
+                if error_code == 'username_in_use':
+                    messages.error(request, '此帳號已被註冊，請選擇其他帳號或嘗試登入。')
+                elif error_code == 'email_in_use':
+                    messages.error(request, '此電子信箱已被註冊，請使用其他信箱或嘗試登入。')
                 else:
                     messages.error(request, error)
     
     @staticmethod
     def check_username_availability(username):
-        """檢查帳號是否可用"""
-        return not User.objects.filter(username=username).exists()
+        """檢查帳號是否可用（不區分大小寫）"""
+        return not User.objects.filter(username__iexact=username).exists()
     
     @staticmethod
     def check_email_availability(email):
-        """檢查 email 是否可用"""
-        return not User.objects.filter(email=email).exists()
+        """檢查 email 是否可用（不區分大小寫）"""
+        return not User.objects.filter(email__iexact=email).exists()

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -5,4 +5,5 @@ app_name = "users"
 
 urlpatterns = [
     path('member/', views.member_zone, name='member_zone'),
+    path('register/', views.register, name='register'),
 ]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,5 +1,12 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.contrib import messages
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.contrib.auth import login
+import json
+from .forms import UserRegistrationForm
 
 # Create your views here.
 
@@ -17,3 +24,76 @@ def member_zone(request):
         context['user_cards'] = user_cards
     
     return render(request, 'users/member_zone.html', context)
+
+
+def register(request):
+    """使用者註冊"""
+    if request.method == 'POST':
+        # 判斷是否為 AJAX 請求
+        if request.headers.get('content-type') == 'application/json':
+            return handle_ajax_registration(request)
+        else:
+            # 一般表單提交
+            form = UserRegistrationForm(request.POST)
+            if form.is_valid():
+                # 創建新用戶
+                user = User.objects.create_user(
+                    username=form.cleaned_data['username'],
+                    email=form.cleaned_data['email'],
+                    password=form.cleaned_data['password']
+                )
+                
+                messages.success(request, '註冊成功！請登入您的帳號。')
+                return redirect('pages:login')  # 重定向到登入頁面
+            else:
+                # 表單驗證失敗
+                for field, errors in form.errors.items():
+                    for error in errors:
+                        messages.error(request, error)
+    else:
+        form = UserRegistrationForm()
+    
+    return render(request, 'users/register.html', {'form': form})
+
+
+@csrf_exempt
+def handle_ajax_registration(request):
+    """處理 AJAX 註冊請求"""
+    try:
+        data = json.loads(request.body)
+        form = UserRegistrationForm(data)
+        
+        if form.is_valid():
+            # 創建新用戶
+            user = User.objects.create_user(
+                username=form.cleaned_data['username'],
+                email=form.cleaned_data['email'],
+                password=form.cleaned_data['password']
+            )
+            
+            return JsonResponse({
+                'success': True,
+                'message': '註冊成功！正在跳轉至登入頁面...',
+                'redirect_url': '/login/'  # 登入頁面 URL
+            })
+        else:
+            # 收集所有錯誤訊息
+            errors = {}
+            for field, field_errors in form.errors.items():
+                errors[field] = field_errors[0]  # 取第一個錯誤訊息
+            
+            return JsonResponse({
+                'success': False,
+                'errors': errors
+            })
+    
+    except json.JSONDecodeError:
+        return JsonResponse({
+            'success': False,
+            'message': '請求格式錯誤'
+        })
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'message': f'系統錯誤: {str(e)}'
+        })

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,14 +1,7 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
-from django.contrib import messages
-from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth import login
-import json
 from .forms import UserRegistrationForm
-
-# Create your views here.
+from .services import UserRegistrationService
 
 def member_zone(request):
     """
@@ -19,7 +12,6 @@ def member_zone(request):
     context = {}
     
     if request.user.is_authenticated:
-        # 獲取用戶的卡片資料
         user_cards = request.user.user_cards.select_related('card', 'card__bank').all()
         context['user_cards'] = user_cards
     
@@ -29,71 +21,15 @@ def member_zone(request):
 def register(request):
     """使用者註冊"""
     if request.method == 'POST':
-        # 判斷是否為 AJAX 請求
-        if request.headers.get('content-type') == 'application/json':
-            return handle_ajax_registration(request)
+        form = UserRegistrationForm(request.POST)
+        success, user, error_type = UserRegistrationService.register_user(form)
+        
+        if success:
+            UserRegistrationService.handle_registration_success(request, user)
+            return redirect('pages:login')
         else:
-            # 一般表單提交
-            form = UserRegistrationForm(request.POST)
-            if form.is_valid():
-                # 創建新用戶
-                user = User.objects.create_user(
-                    username=form.cleaned_data['username'],
-                    email=form.cleaned_data['email'],
-                    password=form.cleaned_data['password']
-                )
-                
-                messages.success(request, '註冊成功！請登入您的帳號。')
-                return redirect('pages:login')  # 重定向到登入頁面
-            else:
-                # 表單驗證失敗
-                for field, errors in form.errors.items():
-                    for error in errors:
-                        messages.error(request, error)
+            UserRegistrationService.handle_registration_failure(request, error_type, form)
     else:
         form = UserRegistrationForm()
     
     return render(request, 'users/register.html', {'form': form})
-
-
-@csrf_exempt
-def handle_ajax_registration(request):
-    """處理 AJAX 註冊請求"""
-    try:
-        data = json.loads(request.body)
-        form = UserRegistrationForm(data)
-        
-        if form.is_valid():
-            # 創建新用戶
-            user = User.objects.create_user(
-                username=form.cleaned_data['username'],
-                email=form.cleaned_data['email'],
-                password=form.cleaned_data['password']
-            )
-            
-            return JsonResponse({
-                'success': True,
-                'message': '註冊成功！正在跳轉至登入頁面...',
-                'redirect_url': '/login/'  # 登入頁面 URL
-            })
-        else:
-            # 收集所有錯誤訊息
-            errors = {}
-            for field, field_errors in form.errors.items():
-                errors[field] = field_errors[0]  # 取第一個錯誤訊息
-            
-            return JsonResponse({
-                'success': False,
-                'errors': errors
-            })
-    
-    except json.JSONDecodeError:
-        return JsonResponse({
-            'success': False,
-            'message': '請求格式錯誤'
-        })
-    except Exception as e:
-        return JsonResponse({
-            'success': False,
-            'message': f'系統錯誤: {str(e)}'
-        })

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -23,19 +23,264 @@ Alpine.data('faq_accordion', () => ({
 
 // 註冊頁面的 Alpine.js 功能
 Alpine.data('register_form', () => ({
-  // 密碼顯示狀態追蹤
-  passwordVisible: false,
-  confirmPasswordVisible: false,
-  
-  // 切換密碼顯示/隱藏
-  togglePassword(fieldType) {
-    if (fieldType === 'password') {
-      this.passwordVisible = !this.passwordVisible;
-    } else if (fieldType === 'password_confirm') {
-      this.confirmPasswordVisible = !this.confirmPasswordVisible;
-    }
+  // 表單資料
+  formData: {
+    username: '',
+    email: '',
+    password: '',
+    confirm_password: '',
+    agree_terms: false
   },
   
+  // 錯誤訊息
+  errors: {},
+  
+  // 狀態管理
+  isSubmitting: false,
+  showPassword: false,
+  showConfirmPassword: false,
+
+  // 前端驗證函數
+  validateField(fieldName) {
+    // 清除該欄位的錯誤
+    delete this.errors[fieldName];
+
+    switch(fieldName) {
+      case 'username':
+        this.validateUsername();
+        break;
+      case 'email':
+        this.validateEmail();
+        break;
+      case 'password':
+        this.validatePassword();
+        break;
+      case 'confirm_password':
+        this.validateConfirmPassword();
+        break;
+      case 'agree_terms':
+        this.validateAgreeTerms();
+        break;
+    }
+  },
+
+  validateUsername() {
+    const username = this.formData.username.trim();
+    
+    if (!username) {
+      this.errors.username = '帳號為必填項目';
+      return false;
+    }
+    
+    // 檢查格式：只允許英文大小寫和數字，不能有空格
+    if (!/^[a-zA-Z0-9]+$/.test(username)) {
+      this.errors.username = '帳號只能包含英文字母和數字，不能有空格或特殊字元';
+      return false;
+    }
+    
+    return true;
+  },
+
+  validateEmail() {
+    const email = this.formData.email.trim();
+    
+    if (!email) {
+      this.errors.email = '電子信箱為必填項目';
+      return false;
+    }
+    
+    // 基本的 email 格式驗證
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      this.errors.email = '請輸入有效的電子信箱格式';
+      return false;
+    }
+    
+    return true;
+  },
+
+  validatePassword() {
+    const password = this.formData.password;
+    
+    if (!password) {
+      this.errors.password = '密碼為必填項目';
+      return false;
+    }
+    
+    // 檢查長度
+    if (password.length < 8 || password.length > 20) {
+      this.errors.password = '密碼長度必須在 8-20 個字元之間';
+      return false;
+    }
+    
+    // 檢查格式：只允許英文大小寫和數字，不能有空格
+    if (!/^[a-zA-Z0-9]+$/.test(password)) {
+      this.errors.password = '密碼只能包含英文字母和數字，不能有空格或特殊字元';
+      return false;
+    }
+    
+    // 檢查至少包含一個大寫字母
+    if (!/[A-Z]/.test(password)) {
+      this.errors.password = '密碼必須包含至少一個英文大寫字母';
+      return false;
+    }
+    
+    // 檢查至少包含一個小寫字母
+    if (!/[a-z]/.test(password)) {
+      this.errors.password = '密碼必須包含至少一個英文小寫字母';
+      return false;
+    }
+    
+    return true;
+  },
+
+  validateConfirmPassword() {
+    const confirmPassword = this.formData.confirm_password;
+    
+    if (!confirmPassword) {
+      this.errors.confirm_password = '確認密碼為必填項目';
+      return false;
+    }
+    
+    if (confirmPassword !== this.formData.password) {
+      this.errors.confirm_password = '兩次輸入的密碼不一致，請重新確認';
+      return false;
+    }
+    
+    return true;
+  },
+
+  validateAgreeTerms() {
+    if (!this.formData.agree_terms) {
+      this.errors.agree_terms = '請勾選同意服務條款';
+      return false;
+    }
+    
+    return true;
+  },
+
+  // 驗證整個表單
+  validateForm() {
+    this.errors = {}; // 清除所有錯誤
+    
+    let isValid = true;
+    
+    // 檢查所有必填欄位是否有值
+    if (!this.formData.username.trim()) {
+      this.errors.username = '帳號為必填項目';
+      isValid = false;
+    }
+    
+    if (!this.formData.email.trim()) {
+      this.errors.email = '電子信箱為必填項目';
+      isValid = false;
+    }
+    
+    if (!this.formData.password) {
+      this.errors.password = '密碼為必填項目';
+      isValid = false;
+    }
+    
+    if (!this.formData.confirm_password) {
+      this.errors.confirm_password = '確認密碼為必填項目';
+      isValid = false;
+    }
+    
+    if (!this.formData.agree_terms) {
+      this.errors.agree_terms = '請勾選同意服務條款';
+      isValid = false;
+    }
+    
+    // 如果有缺少必填項目，直接返回，不進行格式驗證
+    if (!isValid) {
+      this.showAlert('請填寫所有必填項目', 'error');
+      return false;
+    }
+    
+    // 進行格式驗證
+    isValid = this.validateUsername() && isValid;
+    isValid = this.validateEmail() && isValid;
+    isValid = this.validatePassword() && isValid;
+    isValid = this.validateConfirmPassword() && isValid;
+    
+    return isValid;
+  },
+
+  // 提交表單
+  async submitForm() {
+    // 先進行前端驗證
+    if (!this.validateForm()) {
+      return;
+    }
+    
+    this.isSubmitting = true;
+    
+    try {
+      // 獲取 CSRF token
+      const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+      
+      const response = await fetch('/users/register/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken
+        },
+        body: JSON.stringify(this.formData)
+      });
+      
+      const result = await response.json();
+      
+      if (result.success) {
+        this.showAlert(result.message, 'success');
+        
+        // 等待 2 秒後跳轉到登入頁面
+        setTimeout(() => {
+          window.location.href = result.redirect_url;
+        }, 2000);
+      } else {
+        // 處理後端驗證錯誤
+        if (result.errors) {
+          this.errors = result.errors;
+        }
+        
+        if (result.message) {
+          this.showAlert(result.message, 'error');
+        }
+      }
+    } catch (error) {
+      this.showAlert('系統錯誤，請稍後重試', 'error');
+      console.error('Registration error:', error);
+    } finally {
+      this.isSubmitting = false;
+    }
+  },
+
+  // 顯示提示訊息
+  showAlert(message, type) {
+    const alertContainer = type === 'error' ? 
+      document.getElementById('error-alerts') : 
+      document.getElementById('success-alerts');
+    
+    // 清除現有的提示
+    document.getElementById('error-alerts').innerHTML = '';
+    document.getElementById('success-alerts').innerHTML = '';
+    
+    const alertClass = type === 'error' ? 'alert alert-error' : 'alert alert-success';
+    const alertHTML = `
+      <div class="${alertClass}">
+        <span>${message}</span>
+      </div>
+    `;
+    
+    alertContainer.innerHTML = alertHTML;
+    
+    // 自動隱藏提示（成功訊息除外）
+    if (type === 'error') {
+      setTimeout(() => {
+        alertContainer.innerHTML = '';
+      }, 5000);
+    }
+  }
 }));
 
 // 登入頁面的 Alpine.js 功能

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -4,7 +4,8 @@ import "htmx.org";
 
 window.Alpine = Alpine;
 
-// FAQ 頁面的 Alpine.js 功能
+
+// faq 頁面的 Q&A
 Alpine.data('faq_accordion', () => ({
   openItem: null,
   
@@ -21,9 +22,10 @@ Alpine.data('faq_accordion', () => ({
   }
 }));
 
-// 註冊頁面的 Alpine.js 功能
+
+
+//  register.html
 Alpine.data('register_form', () => ({
-  // 表單資料
   formData: {
     username: '',
     email: '',
@@ -32,17 +34,12 @@ Alpine.data('register_form', () => ({
     agree_terms: false
   },
   
-  // 錯誤訊息
   errors: {},
   
-  // 狀態管理
-  isSubmitting: false,
   showPassword: false,
   showConfirmPassword: false,
 
-  // 前端驗證函數
   validateField(fieldName) {
-    // 清除該欄位的錯誤
     delete this.errors[fieldName];
 
     switch(fieldName) {
@@ -72,7 +69,6 @@ Alpine.data('register_form', () => ({
       return false;
     }
     
-    // 檢查格式：只允許英文大小寫和數字，不能有空格
     if (!/^[a-zA-Z0-9]+$/.test(username)) {
       this.errors.username = '帳號只能包含英文字母和數字，不能有空格或特殊字元';
       return false;
@@ -89,7 +85,6 @@ Alpine.data('register_form', () => ({
       return false;
     }
     
-    // 基本的 email 格式驗證
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
       this.errors.email = '請輸入有效的電子信箱格式';
@@ -107,25 +102,21 @@ Alpine.data('register_form', () => ({
       return false;
     }
     
-    // 檢查長度
     if (password.length < 8 || password.length > 20) {
       this.errors.password = '密碼長度必須在 8-20 個字元之間';
       return false;
     }
     
-    // 檢查格式：只允許英文大小寫和數字，不能有空格
     if (!/^[a-zA-Z0-9]+$/.test(password)) {
       this.errors.password = '密碼只能包含英文字母和數字，不能有空格或特殊字元';
       return false;
     }
     
-    // 檢查至少包含一個大寫字母
     if (!/[A-Z]/.test(password)) {
       this.errors.password = '密碼必須包含至少一個英文大寫字母';
       return false;
     }
     
-    // 檢查至少包含一個小寫字母
     if (!/[a-z]/.test(password)) {
       this.errors.password = '密碼必須包含至少一個英文小寫字母';
       return false;
@@ -159,131 +150,12 @@ Alpine.data('register_form', () => ({
     return true;
   },
 
-  // 驗證整個表單
-  validateForm() {
-    this.errors = {}; // 清除所有錯誤
-    
-    let isValid = true;
-    
-    // 檢查所有必填欄位是否有值
-    if (!this.formData.username.trim()) {
-      this.errors.username = '帳號為必填項目';
-      isValid = false;
-    }
-    
-    if (!this.formData.email.trim()) {
-      this.errors.email = '電子信箱為必填項目';
-      isValid = false;
-    }
-    
-    if (!this.formData.password) {
-      this.errors.password = '密碼為必填項目';
-      isValid = false;
-    }
-    
-    if (!this.formData.confirm_password) {
-      this.errors.confirm_password = '確認密碼為必填項目';
-      isValid = false;
-    }
-    
-    if (!this.formData.agree_terms) {
-      this.errors.agree_terms = '請勾選同意服務條款';
-      isValid = false;
-    }
-    
-    // 如果有缺少必填項目，直接返回，不進行格式驗證
-    if (!isValid) {
-      this.showAlert('請填寫所有必填項目', 'error');
-      return false;
-    }
-    
-    // 進行格式驗證
-    isValid = this.validateUsername() && isValid;
-    isValid = this.validateEmail() && isValid;
-    isValid = this.validatePassword() && isValid;
-    isValid = this.validateConfirmPassword() && isValid;
-    
-    return isValid;
-  },
-
-  // 提交表單
-  async submitForm() {
-    // 先進行前端驗證
-    if (!this.validateForm()) {
-      return;
-    }
-    
-    this.isSubmitting = true;
-    
-    try {
-      // 獲取 CSRF token
-      const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
-      
-      const response = await fetch('/users/register/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrfToken
-        },
-        body: JSON.stringify(this.formData)
-      });
-      
-      const result = await response.json();
-      
-      if (result.success) {
-        this.showAlert(result.message, 'success');
-        
-        // 等待 2 秒後跳轉到登入頁面
-        setTimeout(() => {
-          window.location.href = result.redirect_url;
-        }, 2000);
-      } else {
-        // 處理後端驗證錯誤
-        if (result.errors) {
-          this.errors = result.errors;
-        }
-        
-        if (result.message) {
-          this.showAlert(result.message, 'error');
-        }
-      }
-    } catch (error) {
-      this.showAlert('系統錯誤，請稍後重試', 'error');
-      console.error('Registration error:', error);
-    } finally {
-      this.isSubmitting = false;
-    }
-  },
-
-  // 顯示提示訊息
-  showAlert(message, type) {
-    const alertContainer = type === 'error' ? 
-      document.getElementById('error-alerts') : 
-      document.getElementById('success-alerts');
-    
-    // 清除現有的提示
-    document.getElementById('error-alerts').innerHTML = '';
-    document.getElementById('success-alerts').innerHTML = '';
-    
-    const alertClass = type === 'error' ? 'alert alert-error' : 'alert alert-success';
-    const alertHTML = `
-      <div class="${alertClass}">
-        <span>${message}</span>
-      </div>
-    `;
-    
-    alertContainer.innerHTML = alertHTML;
-    
-    // 自動隱藏提示（成功訊息除外）
-    if (type === 'error') {
-      setTimeout(() => {
-        alertContainer.innerHTML = '';
-      }, 5000);
-    }
-  }
 }));
 
-// 登入頁面的 Alpine.js 功能
+
+
+
+// login.html 尚未處理
 Alpine.data('login_form', () => ({
   passwordVisible: false,
   
@@ -292,26 +164,23 @@ Alpine.data('login_form', () => ({
   },
 }));
 
-// 訂閱表單的 Alpine.js 功能
+
+// footer.html  訂閱~尚未處理完
 Alpine.data('subscribe_form', () => ({
   email: '',
   isSubmitting: false,
   message: '',
-  messageType: '', // 'success' or 'error'
+  messageType: '',
   
-  // 驗證 email 格式
   isValidEmail() {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(this.email);
   },
   
-  // 提交表單
   async submitForm() {
-    // 重置訊息
     this.message = '';
     this.messageType = '';
     
-    // 驗證 email
     if (!this.email.trim()) {
       this.showMessage('請輸入 Email 地址。', 'error');
       return;
@@ -322,27 +191,15 @@ Alpine.data('subscribe_form', () => ({
       return;
     }
     
-    // 設定提交狀態
     this.isSubmitting = true;
     
     try {
-      // 模擬提交過程（因為目前沒有後端實作）
       await new Promise(resolve => setTimeout(resolve, 1000));
       
-      // 成功訊息
       this.showMessage('感謝您的訂閱！我們將儘快為您提供服務。', 'success');
-      this.email = ''; // 清空輸入
+      this.email = '';
       
-      // TODO: 實際的 API 呼叫應該在這裡
-      // const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
-      // const response = await fetch('/api/subscribe/', {
-      //   method: 'POST',
-      //   headers: { 
-      //     'Content-Type': 'application/json',
-      //     'X-CSRFToken': csrfToken
-      //   },
-      //   body: JSON.stringify({ email: this.email })
-      // });
+
       
     } catch (error) {
       this.showMessage('訂閱失敗，請稍後再試。', 'error');
@@ -351,12 +208,10 @@ Alpine.data('subscribe_form', () => ({
     }
   },
   
-  // 顯示訊息
   showMessage(text, type) {
     this.message = text;
     this.messageType = type;
     
-    // 3秒後自動清除訊息
     setTimeout(() => {
       this.message = '';
       this.messageType = '';

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -5,6 +5,17 @@
 {% block content %}
 {% include 'components/auth-shared.html' with component="page-container" title="登入" %}
 
+<!-- Django Messages 顯示區域 -->
+{% if messages %}
+  <div class="space-y-2 mb-4">
+    {% for message in messages %}
+      <div class="alert alert-{{ message.tags }}">
+        <span>{{ message }}</span>
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}
+
 <!-- 主要登入表單 -->
 <form class="space-y-3" 
       x-data="login_form" 

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -164,6 +164,5 @@
 <!-- 登入連結 -->
 {% include 'components/auth-shared.html' with component="bottom-link" prefix_text="已經有帳號？" link_text="登入" link_url="pages:login" suffix_text="去" %}
 
-  </div>
-</div>
+{% include 'components/auth-shared.html' with component="page-container-end" %}
 {% endblock %}

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -5,16 +5,22 @@
 {% block content %}
 {% include 'components/auth-shared.html' with component="page-container" title="註冊" %}
 
-<!-- 錯誤提示區域 -->
-<div id="error-alerts" class="space-y-2 mb-4"></div>
-
-<!-- 成功提示區域 -->
-<div id="success-alerts" class="space-y-2 mb-4"></div>
+<!-- Django Messages 顯示區域 -->
+{% if messages %}
+  <div class="space-y-2 mb-4">
+    {% for message in messages %}
+      <div class="alert alert-{{ message.tags }}">
+        <span>{{ message }}</span>
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}
 
 <!-- 主要註冊表單 -->
 <form class="space-y-3" 
       x-data="register_form" 
-      @submit.prevent="submitForm()">
+      method="post"
+      action="{% url 'users:register' %}">
   {% csrf_token %}
   
   <!-- 帳號欄位 -->
@@ -35,6 +41,24 @@
     <div x-show="errors.username" class="text-error text-sm mt-1" x-text="errors.username"></div>
   </div>
 
+  <!-- 電子郵件欄位 -->
+  <div class="register-field-container">
+    <label for="email" class="register-label">電子郵件</label>
+    <div class="register-relative-container">
+      <input 
+        type="email"
+        id="email"
+        name="email"
+        placeholder="請輸入您的電子郵件"
+        class="register-input"
+        :class="{'input-error': errors.email}"
+        x-model="formData.email"
+        @blur="validateField('email')"
+        required>
+    </div>
+    <div x-show="errors.email" class="text-error text-sm mt-1" x-text="errors.email"></div>
+  </div>
+
   <!-- 密碼欄位 -->
   <div class="register-field-container">
     <label for="password" class="register-label">密碼</label>
@@ -42,7 +66,7 @@
       <input 
         :type="showPassword ? 'text' : 'password'"
         id="password"
-        name="password1"
+        name="password"
         placeholder="請輸入您的密碼"
         class="register-input pr-12"
         :class="{'input-error': errors.password}"
@@ -73,7 +97,7 @@
       <input 
         :type="showConfirmPassword ? 'text' : 'password'"
         id="confirm-password"
-        name="password2"
+        name="confirm_password"
         placeholder="請再次輸入您的密碼"
         class="register-input pr-12"
         :class="{'input-error': errors.confirm_password}"
@@ -97,37 +121,19 @@
     <div x-show="errors.confirm_password" class="text-error text-sm mt-1" x-text="errors.confirm_password"></div>
   </div>
 
-  <!-- 電子郵件欄位 -->
-  <div class="register-field-container">
-    <label for="email" class="register-label">電子郵件</label>
-    <div class="register-relative-container">
-      <input 
-        type="email"
-        id="email"
-        name="email"
-        placeholder="請輸入您的電子郵件"
-        class="register-input"
-        :class="{'input-error': errors.email}"
-        x-model="formData.email"
-        @blur="validateField('email')"
-        required>
-    </div>
-    <div x-show="errors.email" class="text-error text-sm mt-1" x-text="errors.email"></div>
-  </div>
-
   <!-- 服務條款勾選框 -->
   <div class="flex items-start space-x-3">
     <input 
       type="checkbox" 
-      id="terms" 
-      name="terms"
+      id="agree_terms" 
+      name="agree_terms"
       class="register-checkbox"
       :class="{'checkbox-error': errors.agree_terms}"
       x-model="formData.agree_terms"
       @change="validateField('agree_terms')"
       required
     >
-    <label for="terms" class="text-lg text-gray-700 font-normal leading-relaxed">
+    <label for="agree_terms" class="text-lg text-gray-700 font-normal leading-relaxed">
       我同意網站
       <a href="#" id="service-terms" class="register-link">
         服務條款
@@ -144,11 +150,8 @@
   <button 
     type="submit" 
     class="register-btn-primary"
-    :class="{'loading': isSubmitting}"
-    :disabled="isSubmitting"
   >
-    <span x-show="!isSubmitting">建立帳號</span>
-    <span x-show="isSubmitting">處理中...</span>
+    建立帳號
   </button>
 </form>
 

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -5,23 +5,115 @@
 {% block content %}
 {% include 'components/auth-shared.html' with component="page-container" title="註冊" %}
 
+<!-- 錯誤提示區域 -->
+<div id="error-alerts" class="space-y-2 mb-4"></div>
+
+<!-- 成功提示區域 -->
+<div id="success-alerts" class="space-y-2 mb-4"></div>
+
 <!-- 主要註冊表單 -->
 <form class="space-y-3" 
       x-data="register_form" 
-      method="post"
-      action="{% url 'pages:register' %}">
+      @submit.prevent="submitForm()">
   {% csrf_token %}
+  
   <!-- 帳號欄位 -->
-  {% include 'components/auth-shared.html' with component="input-field" field_type="text" field_id="username" field_name="username" label_text="帳號" placeholder="請輸入您的帳號" required="true" %}
+  <div class="register-field-container">
+    <label for="username" class="register-label">帳號</label>
+    <div class="register-relative-container">
+      <input 
+        type="text"
+        id="username"
+        name="username"
+        placeholder="請輸入您的帳號"
+        class="register-input"
+        :class="{'input-error': errors.username}"
+        x-model="formData.username"
+        @blur="validateField('username')"
+        required>
+    </div>
+    <div x-show="errors.username" class="text-error text-sm mt-1" x-text="errors.username"></div>
+  </div>
 
   <!-- 密碼欄位 -->
-  {% include 'components/auth-shared.html' with component="input-field" field_type="password" field_id="password" field_name="password1" label_text="密碼" placeholder="請輸入您的密碼" required="true" has_toggle="true" alpine_type="passwordVisible ? 'text' : 'password'" toggle_action="togglePassword('password')" %}
+  <div class="register-field-container">
+    <label for="password" class="register-label">密碼</label>
+    <div class="register-relative-container">
+      <input 
+        :type="showPassword ? 'text' : 'password'"
+        id="password"
+        name="password1"
+        placeholder="請輸入您的密碼"
+        class="register-input pr-12"
+        :class="{'input-error': errors.password}"
+        x-model="formData.password"
+        @blur="validateField('password')"
+        required>
+      <button 
+        type="button" 
+        class="password-toggle-btn"
+        @click="showPassword = !showPassword"
+        :aria-label="showPassword ? '隱藏密碼' : '顯示密碼'"
+      >
+        <div x-show="!showPassword">
+          {% include 'components/icon.html' with name="eye" class="w-6 h-6" %}
+        </div>
+        <div x-show="showPassword">
+          {% include 'components/icon.html' with name="eye-off" class="w-6 h-6" %}
+        </div>
+      </button>
+    </div>
+    <div x-show="errors.password" class="text-error text-sm mt-1" x-text="errors.password"></div>
+  </div>
 
   <!-- 確認密碼欄位 -->
-  {% include 'components/auth-shared.html' with component="input-field" field_type="password" field_id="confirm-password" field_name="password2" label_text="確認密碼" placeholder="請再次輸入您的密碼" required="true" has_toggle="true" alpine_type="confirmPasswordVisible ? 'text' : 'password'" toggle_action="togglePassword('password_confirm')" aria_visible_var="confirmPasswordVisible" %}
+  <div class="register-field-container">
+    <label for="confirm-password" class="register-label">確認密碼</label>
+    <div class="register-relative-container">
+      <input 
+        :type="showConfirmPassword ? 'text' : 'password'"
+        id="confirm-password"
+        name="password2"
+        placeholder="請再次輸入您的密碼"
+        class="register-input pr-12"
+        :class="{'input-error': errors.confirm_password}"
+        x-model="formData.confirm_password"
+        @blur="validateField('confirm_password')"
+        required>
+      <button 
+        type="button" 
+        class="password-toggle-btn"
+        @click="showConfirmPassword = !showConfirmPassword"
+        :aria-label="showConfirmPassword ? '隱藏確認密碼' : '顯示確認密碼'"
+      >
+        <div x-show="!showConfirmPassword">
+          {% include 'components/icon.html' with name="eye" class="w-6 h-6" %}
+        </div>
+        <div x-show="showConfirmPassword">
+          {% include 'components/icon.html' with name="eye-off" class="w-6 h-6" %}
+        </div>
+      </button>
+    </div>
+    <div x-show="errors.confirm_password" class="text-error text-sm mt-1" x-text="errors.confirm_password"></div>
+  </div>
 
   <!-- 電子郵件欄位 -->
-  {% include 'components/auth-shared.html' with component="input-field" field_type="email" field_id="email" field_name="email" label_text="電子郵件" placeholder="請輸入您的電子郵件" required="true" %}
+  <div class="register-field-container">
+    <label for="email" class="register-label">電子郵件</label>
+    <div class="register-relative-container">
+      <input 
+        type="email"
+        id="email"
+        name="email"
+        placeholder="請輸入您的電子郵件"
+        class="register-input"
+        :class="{'input-error': errors.email}"
+        x-model="formData.email"
+        @blur="validateField('email')"
+        required>
+    </div>
+    <div x-show="errors.email" class="text-error text-sm mt-1" x-text="errors.email"></div>
+  </div>
 
   <!-- 服務條款勾選框 -->
   <div class="flex items-start space-x-3">
@@ -30,6 +122,9 @@
       id="terms" 
       name="terms"
       class="register-checkbox"
+      :class="{'checkbox-error': errors.agree_terms}"
+      x-model="formData.agree_terms"
+      @change="validateField('agree_terms')"
       required
     >
     <label for="terms" class="text-lg text-gray-700 font-normal leading-relaxed">
@@ -43,9 +138,18 @@
       </a>
     </label>
   </div>
+  <div x-show="errors.agree_terms" class="text-error text-sm mt-1" x-text="errors.agree_terms"></div>
 
   <!-- 主要註冊按鈕 -->
-  {% include 'components/auth-shared.html' with component="primary-button" button_text="建立帳號" %}
+  <button 
+    type="submit" 
+    class="register-btn-primary"
+    :class="{'loading': isSubmitting}"
+    :disabled="isSubmitting"
+  >
+    <span x-show="!isSubmitting">建立帳號</span>
+    <span x-show="isSubmitting">處理中...</span>
+  </button>
 </form>
 
 <!-- 分隔線 -->
@@ -57,5 +161,6 @@
 <!-- 登入連結 -->
 {% include 'components/auth-shared.html' with component="bottom-link" prefix_text="已經有帳號？" link_text="登入" link_url="pages:login" suffix_text="去" %}
 
-{% include 'components/auth-shared.html' with component="page-container-end" %}
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
Closes #65 
建立新會員註冊流程:

    修改檔案有:
         a. register.html : 新增message tamplates
         b. views.py : 更動渲染/轉址
         c. urls.py : 設置register的url

    新增檔案有:
         a. form.py : 表單欄位定義 / 資料格式驗 / db創建新會員(user)
         b. services.py : 註冊流程控制 / message處理

<img width="671" height="233" alt="image" src="https://github.com/user-attachments/assets/f6ff2b9a-1b8a-46ae-88c2-64290b18a2c0" />

  