### PR TITLE
feat: 新增隱私權政策及服務條款頁面（需要這個頁面插件才能上web store）#160

### DIFF
--- a/apps/pages/urls.py
+++ b/apps/pages/urls.py
@@ -5,6 +5,7 @@ from . import views
 app_name = "pages"
 urlpatterns = [
     path("download/", views.download, name="download"),
+    path("privacy/", views.privacy, name="privacy"),
     path("", views.main, name="main"),
     path("faq/", views.faq, name="faq"),
     path("calculator/", views.calculator, name="calculator"),
@@ -22,5 +23,9 @@ urlpatterns = [
     path("get-messages/", views.get_messages, name="get_messages"),
     path("calculate-reward/", views.calculate_reward, name="calculate_reward"),
     path("api/main-data/", views.get_main_data, name="get_main_data"),
-    path("api/merchants-by-category/", views.get_merchants_by_category, name="get_merchants_by_category"),
+    path(
+        "api/merchants-by-category/",
+        views.get_merchants_by_category,
+        name="get_merchants_by_category",
+    ),
 ]

--- a/apps/pages/urls.py
+++ b/apps/pages/urls.py
@@ -6,6 +6,7 @@ app_name = "pages"
 urlpatterns = [
     path("download/", views.download, name="download"),
     path("privacy/", views.privacy, name="privacy"),
+    path("tos/", views.tos, name="tos"),
     path("", views.main, name="main"),
     path("faq/", views.faq, name="faq"),
     path("calculator/", views.calculator, name="calculator"),

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -17,6 +17,10 @@ def privacy(request):
     return render(request, "pages/privacy.html")
 
 
+def tos(request):
+    return render(request, "pages/tos.html")
+
+
 def main(request):
     return render(request, "pages/main.html")
 

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from .data.faq_content import FAQ_DATA
 from apps.cards.models import CreditCard
 from apps.rewards.models import RewardCategory
-from django.http import HttpResponse, JsonResponse # Added JsonResponse
+from django.http import HttpResponse, JsonResponse  # Added JsonResponse
 from django.db.models import Prefetch
 from django.utils.html import escape
 from django.views.decorators.csrf import csrf_exempt
@@ -12,8 +12,14 @@ import json
 def download(request):
     return render(request, "pages/download.html")
 
+
+def privacy(request):
+    return render(request, "pages/privacy.html")
+
+
 def main(request):
     return render(request, "pages/main.html")
+
 
 def faq(request):
     context = {"faq_categories": FAQ_DATA["categories"]}
@@ -21,25 +27,29 @@ def faq(request):
 
 
 def get_main_data(request):
-    cards = CreditCard.objects.filter(is_active=True).prefetch_related(
-        'reward_categories'  # 預取回饋分類
-    ).order_by('bank', 'name')
+    cards = (
+        CreditCard.objects.filter(is_active=True)
+        .prefetch_related(
+            "reward_categories"  # 預取回饋分類
+        )
+        .order_by("bank", "name")
+    )
 
     # 一次性獲取所有需要的資料
     banks_set = set()
     reward_categories_set = set()
     merchants_set = set()
     all_cards_data = []
-    
+
     for card in cards:
         banks_set.add(card.bank)
         rewards_data = []
-        
+
         # 處理回饋分類
         for reward in card.reward_categories.filter(is_active=True):
             reward_categories_set.add(reward.category)
             merchants_set.add(reward.scope)
-            
+
             # 處理回饋率顯示
             min_rate, max_rate = reward.min_rate, reward.max_rate
             if min_rate is None and max_rate is None:
@@ -50,94 +60,113 @@ def get_main_data(request):
                 rate_display = f"{max_rate}%"
             else:
                 rate_display = f"{min_rate}%-{max_rate}%"
-                
-            rewards_data.append({
-                'category': reward.category,
-                'scope': reward.scope,
-                'rate': rate_display,
-                'reward_type': reward.reward_type,
-                'category_code': reward.category,
-                'source': 'confirmed'
-            })
+
+            rewards_data.append(
+                {
+                    "category": reward.category,
+                    "scope": reward.scope,
+                    "rate": rate_display,
+                    "reward_type": reward.reward_type,
+                    "category_code": reward.category,
+                    "source": "confirmed",
+                }
+            )
 
         # 處理圖片欄位
         if card.image:
             # 如果有上傳的圖片，使用 MediaStorage 生成正確的 URL
             from apps.cards.storage import MediaStorage
+
             storage = MediaStorage()
             image_url = storage.url(card.image.name)
         else:
             # 如果沒有圖片，使用本地 placeholder 或不同的 placeholder 服務
             # 使用 picsum.photos 作為替代的 placeholder 服務
-            image_url = f'https://picsum.photos/300/180?random={card.id}'
-        
-        all_cards_data.append({
-            'id': card.id,
-            'name': card.name,
-            'bank': card.bank,
-            'image': '',  
-            'rewards': rewards_data
-        })
+            image_url = f"https://picsum.photos/300/180?random={card.id}"
+
+        all_cards_data.append(
+            {
+                "id": card.id,
+                "name": card.name,
+                "bank": card.bank,
+                "image": image_url,
+                "rewards": rewards_data,
+            }
+        )
 
     # 處理銀行資料
-    banks = [{
-        'code': bank.lower().replace(' ', '_'), 
-        'name': bank
-    } for bank in sorted(banks_set)]
+    banks = [
+        {"code": bank.lower().replace(" ", "_"), "name": bank}
+        for bank in sorted(banks_set)
+    ]
 
     # 處理回饋類別選項
     reward_category_map = {}
     reward_categories_choices = []
-    
+
     for category in sorted(reward_categories_set):
-        category_code = category.upper().replace(' ', '_').replace('/', '_')
+        category_code = category.upper().replace(" ", "_").replace("/", "_")
         reward_categories_choices.append((category_code, category))
         reward_category_map[category_code] = category
 
     # 處理店家選項
-    merchants = [{'code': merchant.lower().replace(' ', '_'), 'name': merchant} for merchant in sorted(merchants_set)]
+    merchants = [
+        {"code": merchant.lower().replace(" ", "_"), "name": merchant}
+        for merchant in sorted(merchants_set)
+    ]
 
-    return JsonResponse({
-        'all_cards_data': all_cards_data,
-        'banks': banks,
-        'merchants': merchants,
-        'reward_categories_choices': reward_categories_choices,
-        'reward_category_map': reward_category_map,
-    }, safe=False)
+    return JsonResponse(
+        {
+            "all_cards_data": all_cards_data,
+            "banks": banks,
+            "merchants": merchants,
+            "reward_categories_choices": reward_categories_choices,
+            "reward_category_map": reward_category_map,
+        },
+        safe=False,
+    )
 
 
 # API - 根據優惠類別獲取對應的店家列表
 def get_merchants_by_category(request):
     """根據優惠類別獲取對應的店家列表"""
     category_code = request.GET.get("category_code")
-    
+
     if category_code:
         # 直接查詢所有回饋類別來建立映射
-        reward_categories = RewardCategory.objects.filter(is_active=True).values_list('category', flat=True).distinct()
-        
+        reward_categories = (
+            RewardCategory.objects.filter(is_active=True)
+            .values_list("category", flat=True)
+            .distinct()
+        )
+
         # 建立類別代碼到類別名稱的映射
         reward_category_map = {}
         for category in reward_categories:
-            category_code_mapped = category.upper().replace(' ', '_').replace('/', '_')
+            category_code_mapped = category.upper().replace(" ", "_").replace("/", "_")
             reward_category_map[category_code_mapped] = category
-        
+
         # 獲取實際的類別名稱
         category_name = reward_category_map.get(category_code)
-        
+
         if category_name:
             # 查詢該類別下的所有店家
-            merchants = RewardCategory.objects.filter(
-                category=category_name,
-                is_active=True
-            ).values_list('scope', flat=True).distinct().order_by('scope')
-            
-            merchants_list = [{'code': merchant.lower().replace(' ', '_'), 'name': merchant} for merchant in merchants]
-            
-            return JsonResponse({
-                'merchants': merchants_list
-            })
-    
-    return JsonResponse({'merchants': []})
+            merchants = (
+                RewardCategory.objects.filter(category=category_name, is_active=True)
+                .values_list("scope", flat=True)
+                .distinct()
+                .order_by("scope")
+            )
+
+            merchants_list = [
+                {"code": merchant.lower().replace(" ", "_"), "name": merchant}
+                for merchant in merchants
+            ]
+
+            return JsonResponse({"merchants": merchants_list})
+
+    return JsonResponse({"merchants": []})
+
 
 # 共用的選項生成函數
 def _generate_options_html(default_text, items, value_field, text_field):
@@ -154,7 +183,6 @@ def _generate_options_html(default_text, items, value_field, text_field):
     return options_html
 
 
-
 def calculator(request):
     banks = (
         CreditCard.objects.filter(is_active=True)
@@ -167,20 +195,22 @@ def calculator(request):
     }
     return render(request, "pages/calculator.html", context)
 
+
 # HTMX 用的 API - 根據銀行取得卡片
 def get_cards_by_bank(request):
     bank_name = request.GET.get("bank_select")
 
     if bank_name:
-        cards = CreditCard.objects.filter(bank=bank_name, is_active=True).order_by("name")
-        return HttpResponse(_generate_options_html(
-            "請先選擇銀行，再選擇卡片", 
-            cards, 
-            "id", 
+        cards = CreditCard.objects.filter(bank=bank_name, is_active=True).order_by(
             "name"
-        ))
+        )
+        return HttpResponse(
+            _generate_options_html("請先選擇銀行，再選擇卡片", cards, "id", "name")
+        )
 
-    return HttpResponse('<option value="" selected disabled>請先選擇銀行，再選擇卡片</option>')
+    return HttpResponse(
+        '<option value="" selected disabled>請先選擇銀行，再選擇卡片</option>'
+    )
 
 
 # HTMX 用的 API - 根據卡片取得消費類別
@@ -196,12 +226,9 @@ def get_categories_by_card(request):
             .order_by("category")
         )
 
-        return HttpResponse(_generate_options_html(
-            "請先選擇卡片", 
-            categories, 
-            "category", 
-            "category"
-        ))
+        return HttpResponse(
+            _generate_options_html("請先選擇卡片", categories, "category", "category")
+        )
 
     return HttpResponse('<option value="" selected disabled>請先選擇卡片</option>')
 
@@ -220,16 +247,11 @@ def get_scopes_by_category(request):
             .order_by("scope")
         )
 
-        return HttpResponse(_generate_options_html(
-            "請先選擇消費類別", 
-            scopes, 
-            "scope", 
-            "scope"
-        ))
+        return HttpResponse(
+            _generate_options_html("請先選擇消費類別", scopes, "scope", "scope")
+        )
 
     return HttpResponse('<option value="" selected disabled>請先選擇消費類別</option>')
-
-
 
 
 @csrf_exempt
@@ -341,4 +363,3 @@ def get_messages(request):
         """
 
     return HttpResponse(messages_html)
-

--- a/templates/layouts/footer.html
+++ b/templates/layouts/footer.html
@@ -29,7 +29,7 @@
         <h4 class="text-lg font-semibold mb-4">聯絡我們</h4>
         <ul class="space-y-2 text-gray-300">
           <li><a href="{%url 'pages:privacy'%}" class="hover:text-white transition-colors">隱私權政策</a></li>
-          <li><a href="#" class="hover:text-white transition-colors">服務條款</a></li>
+          <li><a href="{%url 'pages:tos'%}" class="hover:text-white transition-colors">服務條款</a></li>
           <li><a href="#" class="hover:text-white transition-colors">客服與回饋</a></li>
         </ul>
       </div>

--- a/templates/layouts/footer.html
+++ b/templates/layouts/footer.html
@@ -2,7 +2,7 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <!-- 桌機：左一 320px / 左二 220px / 左三 吃滿剩餘 -->
     <div class="grid grid-cols-1 lg:grid-cols-[320px_220px_minmax(0,1fr)] gap-12 items-start">
-      
+
       <!-- 左一：品牌（約 320px） -->
       <div class="space-y-6">
         <h3 class="text-4xl font-bold uppercase tracking-wider">Rewardia</h3>
@@ -28,7 +28,7 @@
       <div>
         <h4 class="text-lg font-semibold mb-4">聯絡我們</h4>
         <ul class="space-y-2 text-gray-300">
-          <li><a href="#" class="hover:text-white transition-colors">隱私權政策</a></li>
+          <li><a href="{%url 'pages:privacy'%}" class="hover:text-white transition-colors">隱私權政策</a></li>
           <li><a href="#" class="hover:text-white transition-colors">服務條款</a></li>
           <li><a href="#" class="hover:text-white transition-colors">客服與回饋</a></li>
         </ul>
@@ -60,10 +60,10 @@
               <span x-show="isSubmitting">訂閱中...</span>
             </button>
           </div>
-          
+
           <!-- 訊息顯示區域 -->
           <div x-show="message" x-transition class="mt-2">
-            <p 
+            <p
               class="text-sm px-2"
               :class="{
                 'text-green-400': messageType === 'success',

--- a/templates/pages/privacy.html
+++ b/templates/pages/privacy.html
@@ -147,7 +147,7 @@
               <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"></path>
               <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"></path>
             </svg>
-            <span class="text-gray-700">電子郵件：<a href="mailto:privacy@rewardia.com" class="text-blue-600 hover:text-blue-800">privacy@rewardia.com</a></span>
+            <span class="text-gray-700">電子郵件：<a href="mailto:legosthes@gmail.com" class="text-blue-600 hover:text-blue-800">legosthes@gmail.com</a></span>
           </div>
 
         </div>

--- a/templates/pages/privacy.html
+++ b/templates/pages/privacy.html
@@ -1,0 +1,159 @@
+{% extends 'layouts/default.html' %}
+{% block title %} 下載專區 - Rewardia{%endblock %}
+{% block content %}
+<!-- 主要橫幅區域 -->
+<div class="relative mx-4 sm:mx-6 lg:mx-10 mb-4 sm:mb-6 lg:mb-8 banner-spacing banner-hidden overflow-hidden">
+  <div class="calculator-container">
+
+    <!-- Page Title -->
+    <div class="mb-12">
+      <h1 class="calculator-title">隱私權政策</h1>
+      <p class="text-lg text-gray-600 my-4">保護您的隱私是我們的首要任務</p>
+    </div>
+
+    <!-- Privacy Policy Content -->
+    <div class="max-w-4xl mx-auto space-y-12">
+
+      <!-- Introduction -->
+      <div class="mb-4 bg-gray-50 rounded-lg p-6 md:p-8">
+        <p class="text-gray-700 leading-relaxed text-lg">
+          非常歡迎您光臨「Rewardia 信用卡回饋比較平台」（以下簡稱本網站），為了讓您能夠安心的使用本網站及瀏覽器擴充功能的各項服務與資訊，特此向您說明本網站的隱私權保護政策，以保障您的權益，請您詳閱下列內容：
+        </p>
+      </div>
+
+      <!-- Section 1 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">一、隱私權保護政策的適用範圍</h2>
+        <p class="text-gray-700 leading-relaxed">
+          隱私權保護政策內容，包括本網站及 Rewardia Chrome 瀏覽器擴充功能如何處理在您使用服務時收集到的個人識別資料。隱私權保護政策不適用於本網站以外的相關連結網站，也不適用於非本網站所委託或參與管理的人員。
+        </p>
+      </section>
+
+      <!-- Section 2 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">二、個人資料的蒐集、處理及利用方式</h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          當您使用 Rewardia 網站或瀏覽器擴充功能時，我們將視該服務功能性質，請您提供必要的個人資料，並在該特定目的範圍內處理及利用您的個人資料；非經您書面同意，本網站不會將個人資料用於其他用途。
+        </p>
+
+        <div class="bg-blue-50 border-l-4 border-blue-500 p-4 mb-6">
+          <h3 class="text-lg font-semibold text-gray-900 mb-3">本網站蒐集的個人資料包括：</h3>
+          <ul class="space-y-2 text-gray-700">
+            <li><strong>電子郵件地址</strong>：用於帳戶創建、身份驗證及服務通知（必要資訊）</li>
+            <li><strong>信用卡資訊</strong>：包括信用卡號碼、發卡銀行等，僅在您主動選擇新增至個人帳戶時才會收集及儲存（選擇性資訊）</li>
+            <li><strong>使用行為資料</strong>：包括信用卡比較紀錄、回饋計算歷程，用於提供個人化推薦服務</li>
+            <li><strong>瀏覽器擴充功能資料</strong>：當您使用 Chrome 擴充功能進行線上購物回饋比較時，我們會記錄購物網站資訊及比較結果，以提供即時的最佳信用卡建議</li>
+          </ul>
+        </div>
+
+        <p class="text-gray-700 leading-relaxed mb-4">
+          於一般瀏覽時，伺服器會自行記錄相關行徑，包括您使用連線設備的 IP 位址、使用時間、使用的瀏覽器、瀏覽及點選資料記錄等，做為我們增進網站服務的參考依據，此記錄為內部應用，決不對外公佈。
+        </p>
+
+        <p class="text-gray-700 leading-relaxed">
+          您可以隨時向我們提出請求，以更正或刪除您的帳戶或本網站所蒐集的個人資料等隱私資訊。聯繫方式請見最下方聯繫管道。
+        </p>
+      </section>
+
+      <!-- Section 3 -->
+      <section class=" mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">三、資料之保護</h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          鑑於本服務涉及敏感的金融資訊，本網站採用適當的資訊安全措施保護您的個人資料：
+        </p>
+
+        <div class="bg-green-50 rounded-lg p-4">
+          <ul class="space-y-3 text-gray-700">
+
+            <li class="flex items-start">
+              <svg class="w-5 h-5 text-green-600 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+              </svg>
+              定期進行資安檢測及弱點掃描，確保系統安全性
+            </li>
+            <li class="flex items-start">
+              <svg class="w-5 h-5 text-green-600 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+              </svg>
+              採用業界標準的安全措施保護資料傳輸及儲存
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Section 4 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">四、網站對外的相關連結</h2>
+        <p class="text-gray-700 leading-relaxed">
+          本網站的網頁提供其他網站的網路連結，您也可經由本網站所提供的連結，點選進入其他網站。但該連結網站不適用本網站的隱私權保護政策，您必須參考該連結網站中的隱私權保護政策。
+        </p>
+      </section>
+
+      <!-- Section 5 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">五、與第三人共用個人資料之政策</h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          本網站絕不會提供、交換、出租或出售任何您的個人資料給其他個人、團體、私人企業或公務機關，特別是您的信用卡資訊，但有法律依據或合約義務者，不在此限。
+        </p>
+
+        <div class="bg-red-50 border-l-4 border-red-500 p-4">
+          <p class="text-gray-700 font-semibold">
+            重要聲明：您的信用卡號碼及相關金融資訊絕不會與任何第三方分享，僅用於為您提供個人化的回饋比較服務。
+          </p>
+        </div>
+      </section>
+
+      <!-- Section 6 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">六、Cookie 及瀏覽器擴充功能資料之使用</h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          為了提供您最佳的服務體驗，本網站及 Chrome 擴充功能會使用以下技術：
+        </p>
+
+        <div class="space-y-4">
+          <div class="border-l-4 border-blue-400 px-4">
+            <h4 class="font-semibold text-gray-900">Cookie</h4>
+            <p class="text-gray-700 text-sm">在您的電腦中放置並取用我們的 Cookie，用於記住您的偏好設定及提供個人化服務</p>
+          </div>
+          <div class="border-l-4 border-green-400 px-4">
+            <h4 class="font-semibold text-gray-900">瀏覽器擴充功能</h4>
+            <p class="text-gray-700 text-sm">當您使用 Rewardia Chrome 擴充功能時，我們會偵測您正在瀏覽的購物網站，以提供即時的信用卡回饋比較建議</p>
+          </div>
+          <div class="border-l-4 border-purple-400 px-4">
+            <h4 class="font-semibold text-gray-900">本機儲存</h4>
+            <p class="text-gray-700 text-sm">部分資料會儲存在您的瀏覽器中，以提升服務效能</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 7 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">七、隱私權保護政策之修正</h2>
+        <p class="text-gray-700 leading-relaxed">
+          本網站隱私權保護政策將因應需求隨時進行修正，修正後的條款將刊登於網站上，並透過電子郵件通知註冊用戶。
+        </p>
+      </section>
+
+      <!-- Section 8 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">八、聯繫管道</h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          對於本站之隱私權政策有任何疑問，或者想提出變更、移除個人資料之請求，請透過以下方式聯繫我們：
+        </p>
+
+        <div class="bg-gray-50 rounded-lg p-4 space-y-2">
+          <div class="flex items-center">
+            <svg class="w-5 h-5 text-gray-500 mr-3" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"></path>
+              <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"></path>
+            </svg>
+            <span class="text-gray-700">電子郵件：<a href="mailto:privacy@rewardia.com" class="text-blue-600 hover:text-blue-800">privacy@rewardia.com</a></span>
+          </div>
+
+        </div>
+      </section>
+
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/pages/privacy.html
+++ b/templates/pages/privacy.html
@@ -1,5 +1,5 @@
 {% extends 'layouts/default.html' %}
-{% block title %} 下載專區 - Rewardia{%endblock %}
+{% block title %} 隱私權政策 - Rewardia{%endblock %}
 {% block content %}
 <!-- 主要橫幅區域 -->
 <div class="relative mx-4 sm:mx-6 lg:mx-10 mb-4 sm:mb-6 lg:mb-8 banner-spacing banner-hidden overflow-hidden">

--- a/templates/pages/privacy.html
+++ b/templates/pages/privacy.html
@@ -6,13 +6,13 @@
   <div class="calculator-container">
 
     <!-- Page Title -->
-    <div class="mb-12">
+    <div class="mb-6">
       <h1 class="calculator-title">隱私權政策</h1>
       <p class="text-lg text-gray-600 my-4">保護您的隱私是我們的首要任務</p>
     </div>
 
     <!-- Privacy Policy Content -->
-    <div class="max-w-4xl mx-auto space-y-12">
+    <div class=" mx-auto space-y-12">
 
       <!-- Introduction -->
       <div class="mb-4 bg-gray-50 rounded-lg p-6 md:p-8">
@@ -152,6 +152,11 @@
 
         </div>
       </section>
+
+      <div class="text-center py-8 border-t border-gray-200">
+        <p class="text-sm text-gray-500">最後更新日期：2025年9月</p>
+        <p class="text-sm text-gray-400 mt-2">如有任何疑問，請聯繫我們的客服團隊</p>
+      </div>
 
     </div>
   </div>

--- a/templates/pages/tos.html
+++ b/templates/pages/tos.html
@@ -33,10 +33,6 @@
             <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
             <div>Rewardia 有權於任何時間修改或變更本服務條款之內容，修改後的服務條款內容將公佈於網站上，Rewardia 將不會個別通知使用者，建議您隨時注意該等修改或變更。您於任何修改或變更後繼續使用本服務時，視為您已閱讀、瞭解並同意接受該等修改或變更。</div>
           </li>
-          <li class="flex items-start">
-            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
-            <div>您同意 Rewardia 得不定期提供會員各種信用卡優惠資訊、理財教學內容等資訊至會員所登錄的電子信箱帳號。若您拒絕接受行銷，請您於收到訊息後與 Rewardia 客服聯絡，我們將立即為您處理。</div>
-          </li>
         </ul>
       </section>
 
@@ -66,7 +62,7 @@
         <ul class="space-y-4 text-gray-700 leading-relaxed">
           <li class="flex items-start">
             <div class="w-2 h-2 bg-blue-600 rounded-full mt-2 mr-3 flex-shrink-0"></div>
-            <div><strong>信用卡比較平台：</strong>Rewardia 是一個獨立的信用卡回饋比較平台。在這個平台上面，您可以比較由銀行及金融機構提供的信用卡產品，包括回饋率、年費、優惠等資訊。我們不會跟您收取任何費用。</div>
+            <div><strong>信用卡比較平台：</strong>Rewardia 是一個獨立的信用卡回饋比較平台。在這個平台上面，您可以比較由銀行及金融機構提供的信用卡產品，包括回饋率、優惠等資訊。我們不會跟您收取任何費用。</div>
           </li>
           <li class="flex items-start">
             <div class="w-2 h-2 bg-green-600 rounded-full mt-2 mr-3 flex-shrink-0"></div>
@@ -80,7 +76,7 @@
 
         <div class="bg-yellow-50 border-l-4 border-yellow-500 p-4 mt-6">
           <h3 class="text-lg font-semibold text-gray-900 mb-2">重要聲明</h3>
-          <p class="text-gray-700">本網站所揭載之資訊均係銀行及金融機構提供給我們之現有產品資訊，我們會為您整理及比較分析，但不提供任何與投資、理財或財務相關的顧問或意見，亦未受任何銀行委託受理業務申辦。您應基於自身情況自行決定是否向銀行進一步洽詢或申辦該信用卡產品。</p>
+          <p class="text-gray-700">本網站所揭載之資訊均係銀行及金融機構公開之現有產品資訊，我們會為您整理及比較分析，但不提供任何與投資、理財或財務相關的顧問或意見，亦未受任何銀行委託受理業務申辦。您應基於自身情況自行決定是否向銀行進一步洽詢或申辦該信用卡產品。</p>
         </div>
       </section>
 

--- a/templates/pages/tos.html
+++ b/templates/pages/tos.html
@@ -147,10 +147,7 @@
             <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
             <div>我們盡最大努力保證本網站上資訊、內容和資料的準確性，但您須意識到銀行產品資訊可能隨時變動。我們不承擔因資訊不正確或有遺漏而帶來的任何後果，若有任何疑慮，請您直接洽詢相關銀行。</div>
           </li>
-          <li class="flex items-start">
-            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
-            <div>本網站會提供超連結至銀行官方網站，您一旦點選此類超連結，將前往非屬本公司管理範圍之網站。本公司對於連結網站之內容不負任何責任。</div>
-          </li>
+
         </ul>
 
         <div class="bg-orange-50 border-l-4 border-orange-500 p-4 mt-6">

--- a/templates/pages/tos.html
+++ b/templates/pages/tos.html
@@ -1,5 +1,5 @@
 {% extends 'layouts/default.html' %}
-{% block title %} 下載專區 - Rewardia{%endblock %}
+{% block title %} 服務條款 - Rewardia{%endblock %}
 {% block content %}
 <!-- 主要橫幅區域 -->
 <div class="relative mx-4 sm:mx-6 lg:mx-10 mb-4 sm:mb-6 lg:mb-8 banner-spacing banner-hidden overflow-hidden">

--- a/templates/pages/tos.html
+++ b/templates/pages/tos.html
@@ -1,0 +1,191 @@
+{% extends 'layouts/default.html' %}
+{% block title %} 下載專區 - Rewardia{%endblock %}
+{% block content %}
+<!-- 主要橫幅區域 -->
+<div class="relative mx-4 sm:mx-6 lg:mx-10 mb-4 sm:mb-6 lg:mb-8 banner-spacing banner-hidden overflow-hidden">
+  <div class="calculator-container">
+
+    <!-- Page Title -->
+    <div class="mb-6">
+      <h1 class="calculator-title">服務條款</h1>
+      <p class="text-lg text-gray-600">使用 Rewardia 服務前，請詳閱以下條款</p>
+    </div>
+
+    <!-- Terms of Service Content -->
+    <div class="mx-auto space-y-12">
+
+      <!-- Introduction -->
+      <div class="mb-4 bg-gray-50 rounded-lg p-6 md:p-8">
+        <p class="text-gray-700 leading-relaxed text-lg">
+          歡迎使用 Rewardia 信用卡回饋比較平台。Rewardia 網站及 Chrome 瀏覽器擴充功能（以下簡稱「本服務」）由 Rewardia 團隊經營與所有。本網站文中，凡提及「我們」、「我們的」、「Rewardia」、「本公司」、「本網站」等，泛指 Rewardia 平台及其相關服務。本網站文中凡是提及「您」，泛指「接觸」及/或「使用」本服務之任何人士。只要您開始使用本服務，無論您是否有註冊為本網站之會員，即表示您同意本條款，故請詳閱本條款內容。
+        </p>
+      </div>
+
+      <!-- Section 1: 接受服務 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">接受服務</h2>
+        <ul class="space-y-4 text-gray-700 leading-relaxed">
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>當您完成 Rewardia 之會員註冊手續或開始使用本服務時，即表示已閱讀、瞭解並同意接受本服務條款之所有內容，且完全接受本服務現有與未來衍生的服務項目及內容。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>Rewardia 有權於任何時間修改或變更本服務條款之內容，修改後的服務條款內容將公佈於網站上，Rewardia 將不會個別通知使用者，建議您隨時注意該等修改或變更。您於任何修改或變更後繼續使用本服務時，視為您已閱讀、瞭解並同意接受該等修改或變更。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>您同意 Rewardia 得不定期提供會員各種信用卡優惠資訊、理財教學內容等資訊至會員所登錄的電子信箱帳號。若您拒絕接受行銷，請您於收到訊息後與 Rewardia 客服聯絡，我們將立即為您處理。</div>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Section 2: 會員註冊 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">會員註冊</h2>
+        <ul class="space-y-4 text-gray-700 leading-relaxed">
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>於接受本服務的同時，您可以選擇是否註冊成為 Rewardia 的會員。若您無意註冊為 Rewardia 的會員，仍可持續造訪並瀏覽本網站，但使用本服務的範圍將可能受到限制。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>為了確保會員之個人資料、隱私及消費者權益之保護，在您註冊成為 Rewardia 會員的過程中，本網站將會蒐集您的個人資料並依照中華民國「個人資料保護法」與相關法令之規範下，根據本網站服務條款及隱私權政策之聲明蒐集、處理及利用您的個人資料。</div>
+          </li>
+        </ul>
+
+        <div class="bg-blue-50 border-l-4 border-blue-500 p-4 mt-6">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">蒐集之目的</h3>
+          <p class="text-gray-700">Rewardia 蒐集您個人資料之目的在於進行信用卡回饋比較服務、會員管理與服務、個人化推薦及相關分析研究。</p>
+        </div>
+      </section>
+
+      <!-- Section 3: 服務內容 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">服務內容</h2>
+        <ul class="space-y-4 text-gray-700 leading-relaxed">
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-blue-600 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div><strong>信用卡比較平台：</strong>Rewardia 是一個獨立的信用卡回饋比較平台。在這個平台上面，您可以比較由銀行及金融機構提供的信用卡產品，包括回饋率、年費、優惠等資訊。我們不會跟您收取任何費用。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-green-600 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div><strong>Chrome 瀏覽器擴充功能：</strong>我們提供 Chrome 瀏覽器擴充功能，可在您線上購物時即時比較不同信用卡的回饋率，協助您選擇最適合的付款方式。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-purple-600 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div><strong>回饋計算工具：</strong>提供信用卡回饋試算功能，幫助您了解不同消費情境下的回饋收益。</div>
+          </li>
+        </ul>
+
+        <div class="bg-yellow-50 border-l-4 border-yellow-500 p-4 mt-6">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">重要聲明</h3>
+          <p class="text-gray-700">本網站所揭載之資訊均係銀行及金融機構提供給我們之現有產品資訊，我們會為您整理及比較分析，但不提供任何與投資、理財或財務相關的顧問或意見，亦未受任何銀行委託受理業務申辦。您應基於自身情況自行決定是否向銀行進一步洽詢或申辦該信用卡產品。</p>
+        </div>
+      </section>
+
+      <!-- Section 4: 守法義務及承諾 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">守法義務及承諾</h2>
+        <p class="text-gray-700 leading-relaxed mb-4">
+          您承諾絕不為任何非法目的或以任何非法方式使用本服務，並承諾遵守中華民國相關法規及一切使用網際網路之國際慣例。您同意並保證不得利用本服務從事侵害他人權益或違法之行為，包括但不限於：
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="bg-red-50 rounded-lg p-4">
+            <h4 class="font-semibold text-gray-900 mb-2">禁止行為</h4>
+            <ul class="space-y-2 text-sm text-gray-700">
+              <li>• 發布不實信用卡資訊</li>
+              <li>• 惡意操作擴充功能</li>
+              <li>• 冒用他人身份註冊</li>
+              <li>• 散布惡意軟體或病毒</li>
+            </ul>
+          </div>
+          <div class="bg-red-50 rounded-lg p-4">
+            <h4 class="font-semibold text-gray-900 mb-2">侵權行為</h4>
+            <ul class="space-y-2 text-sm text-gray-700">
+              <li>• 侵犯智慧財產權</li>
+              <li>• 未經授權商業使用</li>
+              <li>• 複製或轉售網站內容</li>
+              <li>• 干擾系統正常運作</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Section 5: 服務之變更、停止及中斷 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">服務之變更、停止及中斷</h2>
+        <ul class="space-y-4 text-gray-700 leading-relaxed">
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>您同意 Rewardia 所提供本服務之範圍，Rewardia 均得視業務需要及實際情形，增減、變更或終止相關服務的項目或內容，且無需個別通知會員。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>Rewardia 將依一般合理之技術及方式，維持系統及服務之正常運作。但於突發性電子通信設備故障、天災等不可抗力因素時，Rewardia 有權暫停或中斷提供本服務。</div>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Section 6: 智慧財產權 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">智慧財產權</h2>
+        <ul class="space-y-4 text-gray-700 leading-relaxed">
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>Rewardia 所使用之軟體或程式、網站上所有內容，包括但不限於 Chrome 擴充功能、比較演算法、網站設計等，均由本網站依法擁有其智慧財產權。您不得逕自使用、修改、重製或散布。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>若您欲引用或轉載前述內容，必須依法取得 Rewardia 的事前書面同意。違反智慧財產權者，應對 Rewardia 負損害賠償責任。</div>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Section 7: 免責條款 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">免責條款</h2>
+        <ul class="space-y-4 text-gray-700 leading-relaxed">
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>我們盡最大努力保證本網站上資訊、內容和資料的準確性，但您須意識到銀行產品資訊可能隨時變動。我們不承擔因資訊不正確或有遺漏而帶來的任何後果，若有任何疑慮，請您直接洽詢相關銀行。</div>
+          </li>
+          <li class="flex items-start">
+            <div class="w-2 h-2 bg-gray-400 rounded-full mt-2 mr-3 flex-shrink-0"></div>
+            <div>本網站會提供超連結至銀行官方網站，您一旦點選此類超連結，將前往非屬本公司管理範圍之網站。本公司對於連結網站之內容不負任何責任。</div>
+          </li>
+        </ul>
+
+        <div class="bg-orange-50 border-l-4 border-orange-500 p-4 mt-6">
+          <p class="text-gray-700 font-semibold">Chrome 擴充功能免責聲明：</p>
+          <p class="text-gray-700 text-sm mt-2">擴充功能僅提供資訊比較服務，不保證所有網站均可正常運作。使用擴充功能時請注意網站安全性，我們不對第三方網站的安全性負責。</p>
+        </div>
+      </section>
+
+      <!-- Section 8: 責任限度 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">責任限度</h2>
+        <p class="text-gray-700 leading-relaxed">
+          在法律允許的最大範圍內，Rewardia 不承擔因您使用或無法使用本服務所造成的任何直接、間接、附帶或懲罰性損害，包括但不限於利潤損失、資料遺失、業務中斷或任何其他商業損害，無論是否基於保證、合約、侵權或任何其他法律規定。
+        </p>
+      </section>
+
+      <!-- Section 9: 準據法與管轄法院 -->
+      <section class="mb-4 bg-white border border-gray-200 rounded-lg p-6 md:p-8">
+        <h2 class="text-2xl font-bold text-gray-900 mb-6">準據法與管轄法院</h2>
+        <p class="text-gray-700 leading-relaxed">
+          本服務條款之解釋與適用，以及與本服務條款有關或會員與 Rewardia 間因使用服務而產生之爭議，應依照中華民國法律予以處理，並以臺灣臺北地方法院為第一審管轄法院。
+        </p>
+      </section>
+
+      <!-- Last Updated -->
+      <div class="text-center py-8 border-t border-gray-200">
+        <p class="text-sm text-gray-500">最後更新日期：2025年9月</p>
+        <p class="text-sm text-gray-400 mt-2">如有任何疑問，請聯繫我們的客服團隊</p>
+      </div>
+
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
close #160 
可以簡單看一下裡面的內容，如果覺得有缺也可以提供

隱私權政策頁面
<img width="1218" height="768" alt="Screenshot 2025-09-16 at 10 32 16 PM" src="https://github.com/user-attachments/assets/8b4acb57-5b23-4126-b931-42567dc2b6cf" />
<img width="1203" height="754" alt="Screenshot 2025-09-16 at 10 32 26 PM" src="https://github.com/user-attachments/assets/1431e045-78af-452e-88c3-193600ae91f7" />

服務條款頁面
<img width="1203" height="765" alt="Screenshot 2025-09-16 at 10 32 11 PM" src="https://github.com/user-attachments/assets/c22787af-8d53-435e-a1c1-53297799b050" />
<img width="1207" height="765" alt="Screenshot 2025-09-16 at 10 32 34 PM" src="https://github.com/user-attachments/assets/26e6af64-9114-4868-b84d-41736c08899f" />

